### PR TITLE
Reworked the way keymaps and reports are being built and used.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,15 +1,19 @@
 include = "./config-extend.toml"
-
 target-applies-to-host = false
 
 [unstable]
 config-include = true
 host-config = true
 target-applies-to-host = true
+trim-paths = true
 
 [env]
-DEFMT_LOG = "info"
+DEFMT_LOG = "debug"
 
-[target.thumbv6m-none-eabi]
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
 linker = "flip-link"
-runner = "elf2uf2-rs -d -s"
+
+# runner = "elf2uf2-rs -d -s"
+
+[profile.release]
+trim-paths = true

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -11,7 +11,7 @@
 				}
 			},
 			"binary": {
-				"path": "/Users/cloudgazing/tmp/rust-analyzer-aarch64-apple-darwin",
+				"path": "/Users/cloudgazing/tmp/rust-analyzer-07-14",
 				"arguments": ["--no-log-buffering"]
 			}
 		}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,18 +88,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
@@ -157,7 +157,7 @@ checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -183,15 +183,6 @@ checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "defmt"
-version = "0.3.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
-dependencies = [
- "defmt 1.0.1",
-]
-
-[[package]]
-name = "defmt"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
@@ -210,7 +201,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -229,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
 dependencies = [
  "critical-section",
- "defmt 1.0.1",
+ "defmt",
 ]
 
 [[package]]
@@ -335,7 +326,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -368,7 +359,7 @@ checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -380,7 +371,7 @@ dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -428,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heapless"
@@ -438,7 +429,17 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "defmt 0.3.100",
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1edcd5a338e64688fbdcb7531a846cfd3476a54784dcb918a0844682bc7ada5"
+dependencies = [
+ "defmt",
  "hash32",
  "stable_deref_trait",
 ]
@@ -469,12 +470,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -498,15 +499,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "log"
@@ -577,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd402d00b0fb94c5aee000029204a46884b1262e0c443f166d86d2c0747e1a1a"
 dependencies = [
  "cortex-m",
- "defmt 1.0.1",
+ "defmt",
 ]
 
 [[package]]
@@ -611,12 +612,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -638,30 +639,30 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "qubit"
-version = "0.0.175"
+version = "0.0.180"
 dependencies = [
  "constcat",
  "cortex-m",
  "cortex-m-rt",
- "defmt 1.0.1",
+ "defmt",
  "defmt-rtt",
  "embedded-hal 1.0.0",
  "fugit",
- "heapless",
+ "heapless 0.9.1",
  "panic-probe",
  "prettyplease",
  "proc-macro2",
@@ -672,14 +673,14 @@ dependencies = [
  "rp2040-boot2",
  "rp2040-hal",
  "stm32f4xx-hal",
- "syn 2.0.104",
+ "syn 2.0.106",
  "usb-device",
  "usbd-hid",
 ]
 
 [[package]]
 name = "qubit_config"
-version = "0.0.175"
+version = "0.0.180"
 dependencies = [
  "semver 1.0.26",
  "serde",
@@ -688,20 +689,20 @@ dependencies = [
 
 [[package]]
 name = "qubit_device"
-version = "0.0.175"
+version = "0.0.180"
 dependencies = [
  "qubit_config",
 ]
 
 [[package]]
 name = "qubit_macros"
-version = "0.0.175"
+version = "0.0.180"
 dependencies = [
  "chrono",
  "proc-macro2",
  "qubit_config",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -809,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -854,7 +855,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -941,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -964,22 +965,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1002,9 +1003,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap",
  "serde",
@@ -1026,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
@@ -1051,7 +1052,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
 dependencies = [
- "heapless",
+ "heapless 0.8.0",
  "portable-atomic",
 ]
 
@@ -1141,7 +1142,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -1163,7 +1164,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1198,7 +1199,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1209,7 +1210,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1238,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "zerocopy"
@@ -1259,5 +1260,5 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ members = [
 default-members = ["crates/qubit"]
 
 [workspace.package]
+version = "0.0.180"
 authors = ["cloudgazing"]
 edition = "2024"
+repository = "https://github.com/cloudgazing/qubit"
 license = "MIT OR Apache-2.0"
 publish = false
 
@@ -23,10 +25,10 @@ defmt = "1.0.1"
 defmt-rtt = "1.0.0"
 embedded-hal = "1.0.0"
 fugit = "0.3.7"
-heapless = { version = "0.8.0" }
+heapless = { version = "0.9.1" }
 panic-probe = { version = "1.0.0", features = ["print-defmt"] }
-prettyplease = "0.2.36"
-proc-macro2 = "1.0.95"
+prettyplease = "0.2.37"
+proc-macro2 = "1.0.101"
 qubit_config = { path = "crates/qubit_config" }
 qubit_device = { path = "crates/qubit_device" }
 qubit_macros = { path = "crates/qubit_macros" }
@@ -36,22 +38,27 @@ rp2040-hal = { version = "0.11.0", features = ["critical-section-impl", "rt"] }
 semver = "1.0.26"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_arrays = "0.2.0"
-serde_json = "1.0.141"
+serde_json = "1.0.143"
 stm32f4xx-hal = { version = "0.22.1", features = ["usb_fs"] }
-syn = "2.0.104"
-toml = "0.9.2"
+syn = "2.0.106"
+toml = "0.9.5"
 usb-device = "0.3.2"
 usbd-hid = "0.8.2"
 usbd-serial = "0.2.2"
 
 [workspace.lints.clippy]
+infinite_loop = "warn"
 pedantic = "warn"
 todo = "warn"
 undocumented_unsafe_blocks = "warn"
+unnecessary_safety_comment = "warn"
+unnecessary_safety_doc = "warn"
+wildcard_dependencies = "warn"
 
 [workspace.lints.rust]
+unexpected_cfgs = "warn"
+unsafe_op_in_unsafe_fn = "deny"
 unused_crate_dependencies = "warn"
-unexpected_cfgs = { level = "warn" }
 
 [profile.dev]
 opt-level = "s"

--- a/crates/qubit/Cargo.toml
+++ b/crates/qubit/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "qubit"
-version = "0.0.175"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 description = "Qubit Firmware."
+repository.workspace = true
 license.workspace = true
 publish.workspace = true
 
@@ -41,7 +42,7 @@ stm32f4xx-hal = { workspace = true, features = ["stm32f411"] }
 
 [features]
 default = ["defmt", "silverplate"]
-defmt = ["defmt-rtt", "dep:defmt", "heapless/defmt-03"]
+defmt = ["defmt-rtt", "dep:defmt", "heapless/defmt"]
 silverplate = []
 
 [lints]

--- a/crates/qubit/build.rs
+++ b/crates/qubit/build.rs
@@ -86,11 +86,9 @@ fn main() {
 	let memory_x = {
 		const KEYMAP_SIZE: usize = device::LAYER0.get_packed_size();
 
-		output_linker_script::<qubit_config::keyboard::KeyboardConfiguration<KEYMAP_SIZE>>(
-			mcu,
-			device::FLASH,
-			device_type,
-		)
+		type Keymaps = qubit_config::keyboard::Keymaps<KEYMAP_SIZE>;
+
+		output_linker_script::<Keymaps>(mcu, device::FLASH, device_type)
 	};
 
 	let mut mem_x_file = File::create(out.join("memory.x")).unwrap();

--- a/crates/qubit/src/time.rs
+++ b/crates/qubit/src/time.rs
@@ -5,7 +5,13 @@ use rp2040_hal as hal;
 use hal::Timer;
 use hal::fugit::MicrosDurationU64;
 
+#[derive(Debug)]
+pub enum Error {
+	WouldBlock,
+}
+
 /// A `CountDown` implementation that was part of `embedded_hall` 2.0.
+// #[derive(Debug)]
 pub struct CountDown {
 	timer: Timer,
 	period: MicrosDurationU64,
@@ -28,8 +34,8 @@ impl CountDown {
 	pub fn start<T: Into<MicrosDurationU64>>(&mut self, count: T) {
 		self.period = count.into();
 
-		let next_end = self.timer.get_counter().ticks();
-		self.next_end = Some(next_end.wrapping_add(self.period.to_micros()));
+		let next_end = self.timer.get_counter().ticks().wrapping_add(self.period.to_micros());
+		self.next_end = Some(next_end);
 	}
 
 	/// "Blockingly" wait until the countdown is finished.
@@ -42,7 +48,7 @@ impl CountDown {
 	/// # Panics
 	///
 	/// Panics if the countdown was not started.
-	pub fn wait(&mut self) -> Result<(), &'static str> {
+	pub fn wait(&mut self) -> Result<(), Error> {
 		if let Some(end) = self.next_end {
 			let current_ticks = self.timer.get_counter().ticks();
 
@@ -51,7 +57,7 @@ impl CountDown {
 
 				Ok(())
 			} else {
-				Err("not finished")
+				Err(Error::WouldBlock)
 			}
 		} else {
 			panic!("CountDown not started!");

--- a/crates/qubit/src/usb.rs
+++ b/crates/qubit/src/usb.rs
@@ -10,7 +10,9 @@ use crate::setup::{UsbBus, UsbBusAllocator};
 mod keyboard;
 
 // USB singletons.
+#[unsafe(link_section = ".uninit.USB_BUS_ALLOC")]
 static mut USB_BUS_ALLOC: MaybeUninit<UsbBusAllocator> = MaybeUninit::uninit();
+#[unsafe(link_section = ".uninit.USB_DEVICE")]
 static mut USB_DEVICE: MaybeUninit<UsbDevice<UsbBus>> = MaybeUninit::uninit();
 
 #[derive(Debug)]
@@ -45,7 +47,7 @@ impl QubitDevice {
 		// The same order the classes were initialized needs to be used when polling the usb bus.
 		// See the [`poll_device`] function.
 
-		// SAFETY: Serial was initialized above and the caller guarantees this will be called only once.
+		// SAFETY: The caller guarantees this will be called only once.
 		#[cfg(keyboard)]
 		let keyboard = unsafe { keyboard::KeyboardInstance::new(usb_bus_alloc, matrix) };
 

--- a/crates/qubit/src/usb/keyboard.rs
+++ b/crates/qubit/src/usb/keyboard.rs
@@ -1,8 +1,5 @@
 use core::mem::MaybeUninit;
 
-use qubit_config::keyboard::keycodes::{
-	KM_LALT, KM_LCTRL, KM_LMETA, KM_LSHIFT, KM_RALT, KM_RCTRL, KM_RMETA, KM_RSHIFT,
-};
 use usb_device::bus::UsbBusAllocator;
 use usbd_hid::hid_class::{HIDClass, HidClassSettings, HidCountryCode, HidProtocol, HidSubClass, ProtocolModeConfig};
 
@@ -15,49 +12,25 @@ mod report;
 #[cfg(feature = "silverplate")]
 mod silverplate;
 
-//
-use qubit_config::keyboard::Keymaps;
-
-use crate::codegen;
-
-pub const PACKED_SIZE: usize = codegen::LAYER0.get_packed_size();
-pub const PRESSED_KEYS_BITMAPS_LEN: usize = PACKED_SIZE.div_ceil(usize::BITS as usize);
-
-pub type KeyboardConfiguration = qubit_config::keyboard::KeyboardConfiguration<PACKED_SIZE>;
-//
-
-#[used]
-#[unsafe(link_section = ".keyboard")]
-static CONFIG: KeyboardConfiguration = KeyboardConfiguration {
-	keymaps: Keymaps {
-		keymap_0: codegen::LAYER0.get_packed(),
-		keymap_1: codegen::LAYER1.get_packed(),
-		keymap_2: codegen::LAYER2.get_packed(),
-		keymap_3: codegen::LAYER3.get_packed(),
-		keymap_4: codegen::LAYER4.get_packed(),
-	},
-};
-
 /// HID class for a keyboard device.
+#[unsafe(link_section = ".uninit.HID_CLASS")]
 static mut HID_CLASS: MaybeUninit<HIDClass<'static, UsbBus>> = MaybeUninit::uninit();
 
 #[derive(Debug)]
 pub struct KeyboardInstance {
-	is_nkro: bool,
-	prev_nkro_report: report::KeyboardNkroReport,
-	prev_6kro_report: report::Keyboard6kroReport,
 	matrix: KeyboardMatrix,
+	is_nkro: bool,
+	report_state: report::ReportState,
+	keymaps_state: keymaps::KeymapsState,
 }
 
 impl KeyboardInstance {
-	/// Creates a new [`KeyboardInstance`] and initializes required static state.
+	/// Creates a new [`KeyboardInstance`].
 	///
 	/// # Safety
 	///
-	/// This function must only be called **once** for the entire lifetime of the program.
-	///
-	/// If the `serial` feature is enabled, the caller must ensure the static for the port was
-	/// already initialized using [`init_class`](super::serial::init_class) before calling this method.
+	/// This method sets the value of a `static mut` and should only be called once to prevent the previous values
+	/// from being leaked and other USB device issues that could occur.
 	pub unsafe fn new(usb_bus_alloc: &'static UsbBusAllocator<UsbBus>, matrix: KeyboardMatrix) -> Self {
 		// Set the value of the HID static.
 		let hid_settings = HidClassSettings {
@@ -87,74 +60,42 @@ impl KeyboardInstance {
 			(*ptr).write(hid_class);
 		}
 
-		// SAFETY: The caller guarantees this will be called only once.
-		unsafe {
-			keymaps::init_active_keymaps();
-		}
-
 		Self {
-			is_nkro,
-			prev_nkro_report: [0; 34],
-			prev_6kro_report: [0; 9],
 			matrix,
+			is_nkro,
+			report_state: report::ReportState::new(),
+			keymaps_state: keymaps::KeymapsState::new(),
 		}
 	}
 
 	/// Scans the keyboard matrix, constructs a HID report, and sends it over USB (if changed).
 	/// A critical section is used to ensure safe, exclusive access to global mutable state.
 	pub fn send_pressed_keys(&mut self) {
-		let pressed_keys = self.matrix.get_pressed_keys();
+		let scanned_keys = self.matrix.get_pressed_keys();
 
-		if self.is_nkro {
-			// SAFETY: The active keymap was initialized before this call.
-			let report = unsafe { report::construct_nkro_report(pressed_keys) };
-
-			if report != self.prev_nkro_report {
-				cortex_m::interrupt::free(|_| {
-					let hid_class = {
-						let ptr = &raw const HID_CLASS;
-
-						// SAFETY: This is safe because:
-						//
-						// * The content was fully initialized when this struct was created.
-						// * We access this inside the critical section which prevents two mutable references
-						// to the value from being created.
-						unsafe { (*ptr).assume_init_ref() }
-					};
-
-					_ = hid_class.push_raw_input(report.as_ref());
-				});
-
-				self.prev_nkro_report = report;
-
-				#[cfg(feature = "defmt")]
-				report::log_nkro_report(report);
-			}
+		let report_opt = if self.is_nkro {
+			self.report_state
+				.build_nkro_report(&mut self.keymaps_state, &scanned_keys)
 		} else {
-			// SAFETY: The active keymap was initialized before this call.
-			let report = unsafe { report::construct_6kro_report(pressed_keys) };
+			self.report_state
+				.build_6kro_report(&mut self.keymaps_state, &scanned_keys)
+		};
 
-			if report != self.prev_6kro_report {
-				cortex_m::interrupt::free(|_| {
-					let hid_class = {
-						let ptr = &raw const HID_CLASS;
+		if let Some(report) = report_opt {
+			cortex_m::interrupt::free(|_| {
+				let hid_class = {
+					let ptr = &raw const HID_CLASS;
 
-						// SAFETY: This is safe because:
-						//
-						// * The content was fully initialized when this struct was created.
-						// * We access this inside the critical section which prevents two mutable references
-						// to the value from being created.
-						unsafe { (*ptr).assume_init_ref() }
-					};
+					// SAFETY: This is safe because:
+					//
+					// * The content was fully initialized when this struct was created.
+					// * We access this inside the critical section which prevents two mutable references
+					// to the value from being created.
+					unsafe { (*ptr).assume_init_ref() }
+				};
 
-					_ = hid_class.push_raw_input(report.as_ref());
-				});
-
-				self.prev_6kro_report = report;
-
-				#[cfg(feature = "defmt")]
-				report::log_6kro_report(report);
-			}
+				_ = hid_class.push_raw_input(report);
+			});
 		}
 	}
 }
@@ -214,6 +155,10 @@ pub fn process_incoming_report(keyboard_hid: &mut HIDClass<UsbBus>) {
 }
 
 fn process_led_report(led_byte: u8) {
+	use qubit_config::keyboard::keycodes::{
+		KM_LALT, KM_LCTRL, KM_LMETA, KM_LSHIFT, KM_RALT, KM_RCTRL, KM_RMETA, KM_RSHIFT,
+	};
+
 	let mut left_ctrl = false;
 	let mut left_shift = false;
 	let mut left_alt = false;

--- a/crates/qubit/src/usb/keyboard/keymaps.rs
+++ b/crates/qubit/src/usb/keyboard/keymaps.rs
@@ -1,58 +1,110 @@
-use core::mem::MaybeUninit;
+use core::num::NonZeroU8;
 
-use qubit_config::keyboard::Keymaps;
+pub(super) const PACKED_SIZE: usize = crate::codegen::LAYER0.get_packed_size();
 
-use super::{CONFIG, PACKED_SIZE};
+pub type Keymaps = qubit_config::keyboard::Keymaps<PACKED_SIZE>;
 
-static mut ACTIVE_KEYMAPS: MaybeUninit<Keymaps<PACKED_SIZE>> = MaybeUninit::uninit();
+#[used]
+#[unsafe(link_section = ".keyboard")]
+static DEFAULT_KEYMAPS: Keymaps = Keymaps {
+	keymap_0: crate::codegen::LAYER0.get_packed(),
+	keymap_1: crate::codegen::LAYER1.get_packed(),
+	keymap_2: crate::codegen::LAYER2.get_packed(),
+	keymap_3: crate::codegen::LAYER3.get_packed(),
+	keymap_4: crate::codegen::LAYER4.get_packed(),
+};
 
-/// Get the keymap from the storage.
-///
-/// This does nothing for now and it's just a reminder to implement EEPROM support.
-///
-/// TODO: Keymaps should be stored in an EEPROM or something similar.
-fn fetch_stored_keymap() -> Option<Keymaps<PACKED_SIZE>> {
-	// Here I need to read from the EEPROM chip.
-	let stored_keymap: Option<Keymaps<PACKED_SIZE>> = None;
-
-	stored_keymap
+#[derive(Debug, Clone, Copy)]
+pub enum Layer {
+	L0,
+	L1,
+	L2,
+	L3,
+	L4,
 }
 
-/// # Safety
-///
-/// This function must be called **only once** for the lifetime of the program.
-pub unsafe fn init_active_keymaps() {
-	let keymap = if let Some(keymap) = fetch_stored_keymap() {
-		keymap
-	} else {
-		Keymaps {
-			keymap_0: CONFIG.keymaps.keymap_0,
-			keymap_1: CONFIG.keymaps.keymap_1,
-			keymap_2: CONFIG.keymaps.keymap_2,
-			keymap_3: CONFIG.keymaps.keymap_3,
-			keymap_4: CONFIG.keymaps.keymap_4,
+#[derive(Debug)]
+pub struct KeymapsState {
+	active_keymaps: Keymaps,
+	active_layers: u8,
+}
+
+impl KeymapsState {
+	pub fn new() -> Self {
+		let active_keymaps = Keymaps {
+			keymap_0: DEFAULT_KEYMAPS.keymap_0,
+			keymap_1: DEFAULT_KEYMAPS.keymap_1,
+			keymap_2: DEFAULT_KEYMAPS.keymap_2,
+			keymap_3: DEFAULT_KEYMAPS.keymap_3,
+			keymap_4: DEFAULT_KEYMAPS.keymap_4,
+		};
+
+		Self {
+			active_keymaps,
+			active_layers: 0b0000_0001,
 		}
-	};
-
-	let ptr = &raw mut ACTIVE_KEYMAPS;
-
-	// SAFETY: `ptr` was obtained from a static value and so is guaranteed to be non-null and properly
-	// aligned. This sets the value of the MaybeUninit.
-	unsafe {
-		(*ptr).write(keymap);
 	}
-}
 
-/// # Safety
-///
-/// Calling this function before initializing the active keymap is **undefined behavior**.
-pub const unsafe fn get_keymap_keycode(index: usize) -> u8 {
-	let active_keymap = {
-		let ptr = &raw mut ACTIVE_KEYMAPS;
+	pub fn get_keycode(&self, idx: usize) -> NonZeroU8 {
+		const NO_KEY: NonZeroU8 = NonZeroU8::new(1).unwrap();
 
-		// SAFETY: The caller gurantees the keymap was initialized.
-		unsafe { (*ptr).assume_init_ref() }
-	};
+		let mut active_layers = self.active_layers;
 
-	active_keymap.keymap_0[index]
+		while active_layers != 0 {
+			let set_bit = 7 - active_layers.leading_zeros() as usize;
+
+			let code = match set_bit {
+				0 => self.active_keymaps.keymap_0[idx],
+				1 => self.active_keymaps.keymap_1[idx],
+				2 => self.active_keymaps.keymap_2[idx],
+				3 => self.active_keymaps.keymap_3[idx],
+				4 => self.active_keymaps.keymap_4[idx],
+				_ => panic!(),
+			};
+
+			if let Some(code) = NonZeroU8::new(code) {
+				return code;
+			}
+
+			active_layers &= !(1 << set_bit);
+		}
+
+		NO_KEY
+	}
+
+	pub fn enable_layer(&mut self, layer: Layer) {
+		let layer_num: u8 = match layer {
+			Layer::L0 => 0,
+			Layer::L1 => 1,
+			Layer::L2 => 2,
+			Layer::L3 => 3,
+			Layer::L4 => 4,
+		};
+
+		self.active_layers |= 1 << layer_num;
+	}
+
+	pub fn disable_layer(&mut self, layer: Layer) {
+		let layer_num: u8 = match layer {
+			Layer::L0 => 0,
+			Layer::L1 => 1,
+			Layer::L2 => 2,
+			Layer::L3 => 3,
+			Layer::L4 => 4,
+		};
+
+		self.active_layers &= !(1 << layer_num);
+	}
+
+	// pub fn toggle_layer(&mut self, layer: Layer) {
+	// 	let layer_num: u8 = match layer {
+	// 		Layer::L0 => 0,
+	// 		Layer::L1 => 1,
+	// 		Layer::L2 => 2,
+	// 		Layer::L3 => 3,
+	// 		Layer::L4 => 4,
+	// 	};
+
+	// 	self.active_layers ^= 1 << layer_num;
+	// }
 }

--- a/crates/qubit/src/usb/keyboard/report.rs
+++ b/crates/qubit/src/usb/keyboard/report.rs
@@ -1,18 +1,31 @@
 use core::num::NonZeroU8;
 
-use qubit_config::keyboard::keycodes::{KC_A, KC_LEFTCTRL, KC_RIGHTMETA, RESERVED};
+use qubit_config::keyboard::keycodes::{
+	KC_A, KC_LAYER_0, KC_LAYER_1, KC_LAYER_2, KC_LAYER_3, KC_LAYER_4, KC_LEFTCTRL, KC_RIGHTMETA, RESERVED,
+};
 
-use super::PRESSED_KEYS_BITMAPS_LEN;
 use super::descriptor::KB_REP_ID_IN;
-use super::keymaps::get_keymap_keycode;
+use super::keymaps::{KeymapsState, Layer, PACKED_SIZE};
+use crate::codegen::KeyboardMatrix;
+
+type ScannedKeys = [usize; KeyboardMatrix::BITMAP_COUNT];
 
 // id + modifier + reserved + 6 keys
-pub type Keyboard6kroReport = [u8; 9];
+pub type Report6kro = [u8; 9];
 // id + modifier + 32 bytes bitmap
-pub type KeyboardNkroReport = [u8; 34];
+pub type ReportNkro = [u8; 34];
+
+pub const EMPTY_6KRO_REPORT: Report6kro = [KB_REP_ID_IN, 0, RESERVED, 0, 0, 0, 0, 0, 0];
+pub const EMPTY_NKRO_REPORT: ReportNkro = {
+	let mut report = [0u8; 34];
+
+	report[0] = KB_REP_ID_IN;
+
+	report
+};
 
 /// Checks the keycode is within the range of "normal" codes.
-fn is_normal_key(key_code: NonZeroU8) -> bool {
+fn is_normal(key_code: NonZeroU8) -> bool {
 	// 0xdd  Keypad Hexadecimal
 	const KEYPAD_HEXDEC: NonZeroU8 = NonZeroU8::new(0xDD).unwrap();
 
@@ -21,7 +34,7 @@ fn is_normal_key(key_code: NonZeroU8) -> bool {
 
 /// Checks if the keycode matches a modifier scan code and turns it into it's modifier mask
 /// counterpart.
-fn is_modifier_key(key_code: NonZeroU8) -> Option<NonZeroU8> {
+fn is_modifier(key_code: NonZeroU8) -> Option<NonZeroU8> {
 	if key_code >= KC_LEFTCTRL && key_code <= KC_RIGHTMETA {
 		let modifier_mask: u8 = 1 << (key_code.get() & 0x07);
 
@@ -29,175 +42,286 @@ fn is_modifier_key(key_code: NonZeroU8) -> Option<NonZeroU8> {
 		// a value between 0 and 7.
 		let mask = unsafe { NonZeroU8::new_unchecked(modifier_mask) };
 
-		Some(mask)
-	} else {
+		return Some(mask);
+	}
+
+	None
+}
+
+fn is_layer(keycode: NonZeroU8) -> Option<Layer> {
+	match keycode {
+		KC_LAYER_0 => Some(Layer::L0),
+		KC_LAYER_1 => Some(Layer::L1),
+		KC_LAYER_2 => Some(Layer::L2),
+		KC_LAYER_3 => Some(Layer::L3),
+		KC_LAYER_4 => Some(Layer::L4),
+		_ => None,
+	}
+}
+
+#[derive(Debug)]
+pub struct ReportState {
+	prev_6kro_report: Report6kro,
+	prev_nkro_report: ReportNkro,
+
+	prev_scanned_keys: ScannedKeys,
+	pressed_keys: [Option<NonZeroU8>; PACKED_SIZE],
+}
+
+impl ReportState {
+	pub fn new() -> Self {
+		Self {
+			prev_6kro_report: EMPTY_6KRO_REPORT,
+			prev_nkro_report: EMPTY_NKRO_REPORT,
+
+			prev_scanned_keys: [0; KeyboardMatrix::BITMAP_COUNT],
+			pressed_keys: [None; PACKED_SIZE],
+		}
+	}
+
+	#[allow(
+		clippy::trivially_copy_pass_by_ref,
+		reason = "Lint is triggered only when `scanned_keys` has one element. Makes sense to allow since that has the
+		same size as the target pointer width."
+	)]
+	pub fn build_6kro_report(&mut self, keymaps: &mut KeymapsState, scanned_keys: &ScannedKeys) -> Option<&[u8]> {
+		const USIZE_BITS: usize = usize::BITS as usize;
+
+		let mut report = self.prev_6kro_report;
+
+		for (current_idx, current_bitmap) in scanned_keys.iter().enumerate() {
+			let offset = current_idx * USIZE_BITS;
+
+			let prev_bitmap = self.prev_scanned_keys[current_idx];
+
+			let mut set_bitmap = current_bitmap & !prev_bitmap;
+			let mut cleared_bitmap = prev_bitmap & !current_bitmap;
+
+			while cleared_bitmap != 0 {
+				let bit_pos = cleared_bitmap.trailing_zeros() as usize;
+
+				let flat_idx = offset + bit_pos;
+
+				let keycode = self.pressed_keys[flat_idx].take().unwrap();
+
+				if let Some(layer) = is_layer(keycode) {
+					keymaps.disable_layer(layer);
+				} else if is_normal(keycode) {
+					if let Some(slot) = report[3..9].iter_mut().find(|slot| **slot == keycode.get()) {
+						*slot = 0;
+					}
+				} else if let Some(mod_code) = is_modifier(keycode) {
+					report[1] &= !mod_code.get();
+				}
+
+				cleared_bitmap &= !(1 << bit_pos);
+			}
+
+			while set_bitmap != 0 {
+				let bit_pos = set_bitmap.trailing_zeros() as usize;
+
+				let flat_idx = offset + bit_pos;
+
+				let keycode = keymaps.get_keycode(flat_idx);
+
+				self.pressed_keys[flat_idx] = Some(keycode);
+
+				if let Some(layer) = is_layer(keycode) {
+					keymaps.enable_layer(layer);
+				} else if is_normal(keycode) {
+					if let Some(slot) = report[3..9].iter_mut().find(|slot| **slot == 0) {
+						*slot = keycode.get();
+					}
+				} else if let Some(mod_code) = is_modifier(keycode) {
+					report[1] |= mod_code.get();
+				}
+
+				set_bitmap &= !(1 << bit_pos);
+			}
+
+			self.prev_scanned_keys[current_idx] = *current_bitmap;
+		}
+
+		if report != self.prev_6kro_report {
+			self.prev_6kro_report = report;
+
+			#[cfg(feature = "defmt")]
+			self.log_6kro_report();
+
+			return Some(&self.prev_6kro_report);
+		}
+
 		None
 	}
-}
 
-/// # Safety
-///
-/// Calling this function before the active keymap was initiated is **undefined behavior**.
-pub unsafe fn construct_6kro_report(pressed_keys: [usize; PRESSED_KEYS_BITMAPS_LEN]) -> Keyboard6kroReport {
-	const USIZE_BITS: usize = usize::BITS as usize;
-	const REPORT_LEN: usize = core::mem::size_of::<Keyboard6kroReport>();
+	#[allow(
+		clippy::trivially_copy_pass_by_ref,
+		reason = "Lint is triggered only when `scanned_keys` has one element. Makes sense to allow since that has the
+		same size as the target pointer width."
+	)]
+	pub fn build_nkro_report(&mut self, keymaps: &mut KeymapsState, scanned_keys: &ScannedKeys) -> Option<&[u8]> {
+		const USIZE_BITS: usize = usize::BITS as usize;
 
-	let mut report: Keyboard6kroReport = [KB_REP_ID_IN, 0, RESERVED, 0, 0, 0, 0, 0, 0];
+		let mut report = self.prev_nkro_report;
 
-	let mut i = 3;
+		for (current_idx, current_bitmap) in scanned_keys.iter().enumerate() {
+			let offset = current_idx * USIZE_BITS;
 
-	for (index, mut bitmap) in pressed_keys.into_iter().enumerate() {
-		let offset = index * USIZE_BITS;
+			let prev_bitmap = self.prev_scanned_keys[current_idx];
 
-		while bitmap != 0 {
-			let pressed_bit = bitmap.trailing_zeros() as usize;
+			let mut set_bitmap = current_bitmap & !prev_bitmap;
+			let mut cleared_bitmap = prev_bitmap & !current_bitmap;
 
-			let flat_index = offset + pressed_bit;
+			while cleared_bitmap != 0 {
+				let bit_pos = cleared_bitmap.trailing_zeros() as usize;
 
-			// SAFETY: The caller gurantees the keymap was initiated.
-			let code = unsafe { get_keymap_keycode(flat_index) };
+				let flat_idx = offset + bit_pos;
 
-			if let Some(code) = NonZeroU8::new(code) {
-				if i < REPORT_LEN && is_normal_key(code) {
-					report[i] = code.get();
+				let keycode = self.pressed_keys[flat_idx].take().unwrap();
 
-					i += 1;
-				} else if let Some(mod_code) = is_modifier_key(code) {
-					report[1] |= mod_code.get();
+				if let Some(layer) = is_layer(keycode) {
+					keymaps.disable_layer(layer);
+				} else if is_normal(keycode) {
+					let byte_idx = ((keycode.get() / 8) + 2) as usize;
+					let bit_idx = (keycode.get() % 8) as usize;
+
+					// This will always be within bounds because (u8::MAX / 8) + 2 = 33
+					report[byte_idx] &= !(1 << bit_idx);
+				} else if let Some(mod_code) = is_modifier(keycode) {
+					report[1] &= !mod_code.get();
 				}
+
+				cleared_bitmap &= !(1 << bit_pos);
 			}
 
-			// Clear the bit
-			bitmap &= !(1 << pressed_bit);
-		}
-	}
+			while set_bitmap != 0 {
+				let bit_pos = set_bitmap.trailing_zeros() as usize;
 
-	report
-}
+				let flat_idx = offset + bit_pos;
 
-/// # Safety
-///
-/// Calling this function before the active keymap was initiated is **undefined behavior**.
-pub unsafe fn construct_nkro_report(pressed_keys: [usize; PRESSED_KEYS_BITMAPS_LEN]) -> KeyboardNkroReport {
-	const USIZE_BITS: usize = usize::BITS as usize;
-	const NKRO_REP_LEN: usize = 34;
+				let keycode = keymaps.get_keycode(flat_idx);
 
-	// [report_id, modifier, keys...]
-	let mut report = [0_u8; NKRO_REP_LEN];
+				self.pressed_keys[flat_idx] = Some(keycode);
 
-	report[0] = KB_REP_ID_IN;
+				if let Some(layer) = is_layer(keycode) {
+					keymaps.enable_layer(layer);
+				} else if is_normal(keycode) {
+					let byte_idx = ((keycode.get() / 8) + 2) as usize;
+					let bit_idx = (keycode.get() % 8) as usize;
 
-	for (index, mut bitmap) in pressed_keys.into_iter().enumerate() {
-		let offset = index * USIZE_BITS;
-
-		while bitmap != 0 {
-			let pressed_bit = bitmap.trailing_zeros() as usize;
-
-			let flat_index = offset + pressed_bit;
-
-			// SAFETY: The caller gurantees the keymap was initiated.
-			let code = unsafe { get_keymap_keycode(flat_index) };
-
-			if let Some(code) = NonZeroU8::new(code) {
-				if is_normal_key(code) {
-					let key_code = code.get();
-
-					let byte_index = (key_code / 8) as usize + 2;
-					let bit_index = (key_code % 8) as usize;
-
-					if byte_index < NKRO_REP_LEN {
-						report[byte_index] |= 1 << bit_index;
-					}
-				} else if let Some(mod_code) = is_modifier_key(code) {
+					// This will always be within bounds because (u8::MAX / 8) + 2 = 33
+					report[byte_idx] |= 1 << bit_idx;
+				} else if let Some(mod_code) = is_modifier(keycode) {
 					report[1] |= mod_code.get();
 				}
+
+				set_bitmap &= !(1 << bit_pos);
 			}
 
-			// Clear the bit
-			bitmap &= !(1 << pressed_bit);
+			self.prev_scanned_keys[current_idx] = *current_bitmap;
 		}
+
+		if report != self.prev_nkro_report {
+			self.prev_nkro_report = report;
+
+			#[cfg(feature = "defmt")]
+			self.log_nkro_report();
+
+			return Some(&self.prev_nkro_report);
+		}
+
+		None
 	}
 
-	report
-}
+	#[cfg(feature = "defmt")]
+	pub fn log_6kro_report(&self) {
+		use core::fmt::Write;
 
-#[cfg(feature = "defmt")]
-pub fn log_6kro_report(report: Keyboard6kroReport) {
-	use core::fmt::Write;
+		let mut msg = heapless::String::<700>::new();
 
-	let mut msg = heapless::String::<500>::new();
+		writeln!(msg, "6KRO report sent:").ok();
 
-	let mut keys = report.iter();
+		let mut report = self.prev_6kro_report.iter();
 
-	// remove report id
-	keys.next();
+		// Remove report id.
+		report.next();
 
-	let modifier_msg = if keys.next().is_some_and(|&v| v == 0) {
-		"none"
-	} else {
-		"??"
-	};
+		write!(msg, "Modifiers: [").ok();
 
-	// remove reserved
-	keys.next();
-
-	let mut pressed_keys = heapless::String::<128>::new();
-
-	for (i, key) in keys.enumerate() {
-		if *key == 0 {
-			break;
+		if let Some(mod_byte) = report.next() {
+			write!(msg, "{mod_byte:08b}").ok();
 		}
 
-		if i != 0 {
-			write!(pressed_keys, ", ").unwrap();
+		writeln!(msg, "]").ok();
+
+		// Remove reserved byte.
+		report.next();
+
+		write!(msg, "Keys: [").ok();
+
+		for (i, key) in report.enumerate() {
+			if *key == 0 {
+				break;
+			}
+
+			if i != 0 {
+				write!(msg, ", ").ok();
+			}
+
+			write!(msg, "{key:#04X}").ok();
 		}
 
-		write!(pressed_keys, "0x{key:02}").unwrap();
+		writeln!(msg, "]").ok();
+
+		write!(msg, "---").ok();
+
+		defmt::debug!("{}", msg);
 	}
 
-	writeln!(msg, "6KRO report sent:").ok();
-	writeln!(msg, "Modifiers: {modifier_msg}").ok();
-	writeln!(msg, "Keys: [{pressed_keys}]").ok();
-	write!(msg, "---").ok();
+	#[cfg(feature = "defmt")]
+	pub fn log_nkro_report(&self) {
+		use core::fmt::Write;
 
-	defmt::info!("{}", msg);
-}
+		let mut msg = heapless::String::<1000>::new();
 
-#[cfg(feature = "defmt")]
-pub fn log_nkro_report(report: KeyboardNkroReport) {
-	use core::fmt::Write;
+		writeln!(msg, "NKRO report sent:").ok();
 
-	let mut msg = heapless::String::<500>::new();
+		let mut report = self.prev_nkro_report.iter();
 
-	let mut keys = report.iter();
+		// Remove report id.
+		report.next();
 
-	// remove report id
-	keys.next();
+		write!(msg, "Modifiers: [").ok();
 
-	let modifier_msg = if keys.next().is_some_and(|&v| v == 0) {
-		"none"
-	} else {
-		"??"
-	};
-
-	let mut pressed_keys = heapless::String::<500>::new();
-
-	for (i, key) in keys.enumerate() {
-		if *key == 0 {
-			continue;
+		if let Some(mod_byte) = report.next() {
+			write!(msg, "{mod_byte:08b}").ok();
 		}
 
-		if i != 0 {
-			write!(pressed_keys, ", ").unwrap();
+		writeln!(msg, "]").ok();
+
+		write!(msg, "Keys: [").ok();
+
+		for (i, key) in report.enumerate() {
+			let offset = i * u8::BITS as usize;
+
+			let mut key = *key;
+
+			while key != 0 {
+				let bit_pos = key.trailing_zeros() as usize;
+
+				let keycode = offset + bit_pos;
+
+				write!(msg, "{keycode:#04X}").ok();
+				write!(msg, ", ").ok();
+
+				key &= !(1 << bit_pos);
+			}
 		}
 
-		write!(pressed_keys, "0x{key:02}").unwrap();
+		writeln!(msg, "]").ok();
+
+		write!(msg, "---").ok();
+
+		defmt::debug!("{}", msg);
 	}
-
-	writeln!(msg, "NKRO report sent:").ok();
-	writeln!(msg, "Modifiers: {modifier_msg}").ok();
-	writeln!(msg, "Keys: [{pressed_keys}]").ok();
-	write!(msg, "---").ok();
-
-	defmt::info!("{}", msg);
 }

--- a/crates/qubit/src/usb/keyboard/silverplate.rs
+++ b/crates/qubit/src/usb/keyboard/silverplate.rs
@@ -2,7 +2,6 @@ use core::mem::size_of_val;
 
 use usbd_hid::hid_class::HIDClass;
 
-use super::CONFIG;
 use crate::DEVICE_CONFIG;
 use crate::setup::UsbBus;
 
@@ -76,24 +75,28 @@ pub fn process_vendor_report(hid_class: &HIDClass<UsbBus>, req_byte: u8) {
 
 			_ = hid_class.push_raw_input(&RESPONSE).is_ok();
 		}
+		#[allow(
+			clippy::match_same_arms,
+			reason = "This function needs to be rewritten but I allow this because I want to see what I was trying to do."
+		)]
 		0x02 => {
 			// req info
 
-			{
-				let keymap = &CONFIG.keymaps.keymap_0;
+			// {
+			// 	let keymap = &CONFIG.keymaps.keymap_0;
 
-				let size = keymap.len() as u64;
-				let size: [u8; 8] = size.to_le_bytes();
+			// 	let size = keymap.len() as u64;
+			// 	let size: [u8; 8] = size.to_le_bytes();
 
-				let response: [u8; 10 + 1] = [
-					0x05, // report id
-					0x00, // number of rows
-					0x00, // number of cols
-					size[0], size[1], size[2], size[3], size[4], size[5], size[6], size[7],
-				];
+			// 	let response: [u8; 10 + 1] = [
+			// 		0x05, // report id
+			// 		0x00, // number of rows
+			// 		0x00, // number of cols
+			// 		size[0], size[1], size[2], size[3], size[4], size[5], size[6], size[7],
+			// 	];
 
-				_ = hid_class.push_raw_input(&response).is_ok();
-			}
+			// 	_ = hid_class.push_raw_input(&response).is_ok();
+			// }
 
 			// {
 			// 	let keymap = unsafe { temp_get_active_keymap_ref() };

--- a/crates/qubit_config/Cargo.toml
+++ b/crates/qubit_config/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "qubit_config"
-version = "0.0.175"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
+repository.workspace = true
 license.workspace = true
 publish.workspace = true
 

--- a/crates/qubit_config/src/keyboard.rs
+++ b/crates/qubit_config/src/keyboard.rs
@@ -2,6 +2,7 @@ pub mod keycodes;
 
 pub type PackedKeymap<const S: usize> = [u8; S];
 
+#[derive(Debug)]
 pub struct Keymap<const R: usize, const C: usize>(pub [[u8; C]; R]);
 
 impl<const R: usize, const C: usize> Keymap<R, C> {
@@ -81,11 +82,6 @@ pub struct Keymaps<const S: usize> {
 	pub keymap_2: PackedKeymap<S>,
 	pub keymap_3: PackedKeymap<S>,
 	pub keymap_4: PackedKeymap<S>,
-}
-
-#[derive(Debug)]
-pub struct KeyboardConfiguration<const S: usize> {
-	pub keymaps: Keymaps<S>,
 }
 
 /// Generate a keymap using the predefined keycodes.

--- a/crates/qubit_config/src/keyboard/keycodes.rs
+++ b/crates/qubit_config/src/keyboard/keycodes.rs
@@ -424,11 +424,20 @@ pub const KC_M_EJECTCD: NonZeroU8 = NonZeroU8::new(0xEC).unwrap();
 pub const KC_M_VOLUMEUP: NonZeroU8 = NonZeroU8::new(0xED).unwrap();
 pub const KC_M_VOLUMEDOWN: NonZeroU8 = NonZeroU8::new(0xEE).unwrap();
 pub const KC_M_MUTE: NonZeroU8 = NonZeroU8::new(0xEF).unwrap();
-pub const KC_M_WWW: NonZeroU8 = NonZeroU8::new(0xF0).unwrap();
-pub const KC_M_BACK: NonZeroU8 = NonZeroU8::new(0xF1).unwrap();
-pub const KC_M_FORWARD: NonZeroU8 = NonZeroU8::new(0xF2).unwrap();
-pub const KC_M_STOP: NonZeroU8 = NonZeroU8::new(0xF3).unwrap();
-pub const KC_M_FIND: NonZeroU8 = NonZeroU8::new(0xF4).unwrap();
+
+// TEMPORARY, used for test
+
+pub const KC_LAYER_0: NonZeroU8 = NonZeroU8::new(0xF0).unwrap();
+pub const KC_LAYER_1: NonZeroU8 = NonZeroU8::new(0xF1).unwrap();
+pub const KC_LAYER_2: NonZeroU8 = NonZeroU8::new(0xF2).unwrap();
+pub const KC_LAYER_3: NonZeroU8 = NonZeroU8::new(0xF3).unwrap();
+pub const KC_LAYER_4: NonZeroU8 = NonZeroU8::new(0xF4).unwrap();
+// pub const KC_M_WWW: NonZeroU8 = NonZeroU8::new(0xF0).unwrap();
+// pub const KC_M_BACK: NonZeroU8 = NonZeroU8::new(0xF1).unwrap();
+// pub const KC_M_FORWARD: NonZeroU8 = NonZeroU8::new(0xF2).unwrap();
+// pub const KC_M_STOP: NonZeroU8 = NonZeroU8::new(0xF3).unwrap();
+// pub const KC_M_FIND: NonZeroU8 = NonZeroU8::new(0xF4).unwrap();
+
 pub const KC_M_SCROLLUP: NonZeroU8 = NonZeroU8::new(0xF5).unwrap();
 pub const KC_M_SCROLLDOWN: NonZeroU8 = NonZeroU8::new(0xF6).unwrap();
 pub const KC_M_EDIT: NonZeroU8 = NonZeroU8::new(0xF7).unwrap();

--- a/crates/qubit_config/src/lib.rs
+++ b/crates/qubit_config/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(strict_overflow_ops)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(feature = "build")]

--- a/crates/qubit_config/src/linker/family/cortex_m.rs
+++ b/crates/qubit_config/src/linker/family/cortex_m.rs
@@ -97,6 +97,7 @@ impl MemoryRegion {
 	}
 }
 
+#[derive(Debug)]
 pub struct MemorySpace {
 	pub flash: MemoryRegion,
 	pub ram: MemoryRegion,
@@ -149,6 +150,7 @@ impl MemorySpace {
 	}
 }
 
+#[derive(Debug)]
 pub struct Section {
 	pub section_name: &'static str,
 	pub mem_region_name: &'static str,

--- a/crates/qubit_config/src/usb.rs
+++ b/crates/qubit_config/src/usb.rs
@@ -1,3 +1,4 @@
+#[derive(Debug)]
 pub struct Usb {
 	pub vid: u16,
 	pub pid: u16,

--- a/crates/qubit_device/Cargo.toml
+++ b/crates/qubit_device/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "qubit_device"
-version = "0.0.175"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
+repository.workspace = true
 license.workspace = true
 publish.workspace = true
 

--- a/crates/qubit_device/src/lib.rs
+++ b/crates/qubit_device/src/lib.rs
@@ -1,7 +1,6 @@
 //! A crate that holds the configurations for all the **officially supported** devices.
 
 // #![warn(missing_docs)]
-#![feature(strict_overflow_ops)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod models;

--- a/crates/qubit_device/src/models/cloudgazing/obsidian.rs
+++ b/crates/qubit_device/src/models/cloudgazing/obsidian.rs
@@ -30,7 +30,7 @@ pub const COL_PINS: [&str; COL_NUM] = ["B14", "B15"];
 #[rustfmt::skip]
 pub const LAYER0: Keymap<ROW_NUM, COL_NUM> = keymap! [
 	[KC_0, KC_1],
-	[KC_3, KC_4],
+	[KC_2, KC_LAYER_2],
 ];
 
 // Win keymap
@@ -43,18 +43,18 @@ pub const LAYER1: Keymap<ROW_NUM, COL_NUM> = keymap! [
 //
 #[rustfmt::skip]
 pub const LAYER2: Keymap<ROW_NUM, COL_NUM> = keymap! [
-	[KC_0, KC_1],
-	[KC_3, KC_4],
+	[KC_1, KC_6],
+	[KC_LAYER_3, KC_8],
 ];
 #[rustfmt::skip]
 pub const LAYER3: Keymap<ROW_NUM, COL_NUM> = keymap! [
-	[KC_0, KC_1],
-	[KC_3, KC_4],
+	[KC_A, KC_B],
+	[KC_C, KC_D],
 ];
 #[rustfmt::skip]
 pub const LAYER4: Keymap<ROW_NUM, COL_NUM> = keymap! [
-	[KC_0, KC_1],
-	[KC_3, KC_4],
+	[KC_E, KC_F],
+	[KC_G, KC_H],
 ];
 
 // Keyboard layout

--- a/crates/qubit_macros/Cargo.toml
+++ b/crates/qubit_macros/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "qubit_macros"
-version = "0.0.175"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 description = "Macros for Qubit."
+repository.workspace = true
 license.workspace = true
 publish.workspace = true
 

--- a/crates/qubit_macros/src/import.rs
+++ b/crates/qubit_macros/src/import.rs
@@ -17,19 +17,23 @@ impl syn::parse::Parse for Input {
 
 		let model_ident: Ident = input.parse()?;
 
-		let Ok(author_value) = std::env::var(author_ident.to_string()) else {
-			let err_msg = format!("Failed to read env value {author_ident}");
-			return Err(syn::Error::new(author_ident.span(), err_msg));
+		let author = match std::env::var(author_ident.to_string()) {
+			Ok(value) => Ident::new(&value, author_ident.span()),
+			Err(e) => {
+				let msg = format!("Failed to read env value {author_ident}. {e}");
+
+				return Err(syn::Error::new(author_ident.span(), msg));
+			}
 		};
 
-		let author = Ident::new(&author_value, author_ident.span());
+		let model = match std::env::var(model_ident.to_string()) {
+			Ok(value) => Ident::new(&value, model_ident.span()),
+			Err(e) => {
+				let msg = format!("Failed to read env value {model_ident}. {e}");
 
-		let Ok(model_value) = std::env::var(model_ident.to_string()) else {
-			let err_msg = format!("Failed to read env value {model_ident}");
-			return Err(syn::Error::new(model_ident.span(), err_msg));
+				return Err(syn::Error::new(model_ident.span(), msg));
+			}
 		};
-
-		let model = Ident::new(&model_value, model_ident.span());
 
 		Ok(Self { author, model })
 	}

--- a/crates/qubit_macros/src/keyboard.rs
+++ b/crates/qubit_macros/src/keyboard.rs
@@ -39,6 +39,13 @@ pub fn keyboard_matrix_macro(args: TokenStream, item: TokenStream) -> TokenStrea
 	};
 
 	let struct_impl = {
+		// Get the total amount of keys, excluding the empty spaces.
+		let bitmap_count_const = {
+			let keys_count: usize = keymap.keymap.iter().flatten().filter(|&&x| x != 0).count();
+
+			quote! { pub const BITMAP_COUNT: usize = #keys_count.div_ceil(usize::BITS as usize); }
+		};
+
 		let new_method = {
 			let row_args = fields::map_new_args(mcu, &rows);
 			let col_args = fields::map_new_args(mcu, &cols);
@@ -61,6 +68,7 @@ pub fn keyboard_matrix_macro(args: TokenStream, item: TokenStream) -> TokenStrea
 
 		quote! {
 			impl #struct_name {
+				#bitmap_count_const
 				#new_method
 				#pressed_keys_method
 			}
@@ -110,9 +118,6 @@ fn def_pressed_keys_method(
 			quote! {}
 		}
 	};
-
-	// Get the total amount of keys, excluding the empty spaces.
-	let keys_count: usize = keymap.keymap.iter().flatten().filter(|&&x| x != 0).count();
 
 	let delay_call = match mcu {
 		Mcu::RP2040 | Mcu::STM32F411 => quote! { ::cortex_m::asm::delay(#delay); },
@@ -200,16 +205,14 @@ fn def_pressed_keys_method(
 		}
 	});
 
-	let bitmaps_count = quote! { #keys_count.div_ceil(usize::BITS as usize) };
-
 	quote! {
 		#[doc = r"Scans the key matrix and returns a bitmap of pressed keys."]
-		#visibility fn get_pressed_keys(&mut self) -> [usize; #bitmaps_count] {
+		#visibility fn get_pressed_keys(&mut self) -> [usize; Self::BITMAP_COUNT] {
 			#imports
 
 			const USIZE_BITS: usize = usize::BITS as usize;
 
-			let mut bitmaps = [0_usize; #bitmaps_count];
+			let mut bitmaps = [0_usize; Self::BITMAP_COUNT];
 
 			#(#check_tokens)*
 

--- a/crates/qubit_macros/src/keyboard/attributes.rs
+++ b/crates/qubit_macros/src/keyboard/attributes.rs
@@ -169,7 +169,7 @@ impl syn::parse::Parse for Attributes {
 			}
 		}
 
-		let delay = delay.unwrap_or(40);
+		let delay = delay.unwrap_or(80);
 		let mcu = mcu.ok_or(syn::Error::new(stream.span(), "Missing `mcu` argument."))?;
 		let rows = rows.ok_or(syn::Error::new(stream.span(), "Missing `rows` argument."))?;
 		let cols = cols.ok_or(syn::Error::new(stream.span(), "Missing `cols` argument."))?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,5 +6,5 @@
 # See issue: https://github.com/JoNil/elf2uf2-rs/issues/40
 
 [toolchain]
-channel = "nightly-2025-07-22"
+channel = "nightly-2025-08-30"
 targets = ["thumbv6m-none-eabi", "thumbv7em-none-eabihf"]


### PR DESCRIPTION
The keyboard now has a `KeymapsState` and a `ReportState`. This makes it easier and safer to work with them. For keymaps a static mut value was removed and there is support now for active layers which can be enabled/disabled. For the report some extra info is stored to enable other functionality like switching between layers and differentiating between released and newly pressed keys.

To enable layer functionality some keycodes from HID are used. This is very likely to change and it's only used for now until I find a proper solution.

Other changes:

Removed the `KeyboardConfiguration` struct. The `Keymaps` struct is going to be used directly instead. 
Added a `link_section` attribute for `MaybeUninit` `static mut` values. 
Changed the `CountDown` in the time module to return a proper error instead of a &str. 
Set the `flip-link` linker for all arm targets.
Updated the version of crate dependencies.
Raised rust toolchain nightly version.
Moved the version field to the workspace manifest file to make it easier to increment the version for all workspace crates. Added more rust and and clippy lints.